### PR TITLE
Charlon/docker dev sampleproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,48 +7,42 @@ System Requirements
 * Python (3+)
 * Django (2+)
 * Docker
-
-Setup
------
-
-1. Clone the repository
-
-        $ git clone https://github.com/uw-it-aca/prereq_map
-        $ cd prereq_map
-
-Node
-----
-
-2. Install the node dependencies for the React Demo.
-
-        $ npm install
-
-Webpack
--------
-
-3. Start the webpack "watch mode". This will leave the webpack compiler running
-   and compile bundles automatically when changes are made to the source files.
-   You'll need to restart this command if you make changes to the webpack config.
-
-        $ ./node_modules/.bin/webpack --config webpack.config.js --watch
+* Node
 
 Docker
 ------
 
-4. Docker/Docker Compose is used to containerize your local build environment
+1. Clone the repository
+
+        $ git clone https://github.com/uw-it-aca/prereq-map
+        $ cd prereq-map
+
+2. Docker/Docker Compose is used to containerize your local build environment
     and deploy it to a local container so you can view your application. Docker
     is configured to build an empty 'project' and copy the settings files located
     in the 'docker' directory.
 
         $ docker-compose up
-
-5. In the case that changes are made to the Dockerfile or docker-compose.yml file,
+3. In the case that changes are made to the Dockerfile or docker-compose.yml file,
     you will need to rebuild the image. In this case, 'app' is the name of the
     Docker image for the Django project.
 
         $ docker-compose up --build
 
-View your app
--------------
+4. View your application
 
-Demo: http://localhost:8123/
+        Demo: http://localhost:8000/
+
+Node (local for now)
+------------
+
+1. Install the node dependencies on your local machine (for now). This will create
+   a local 'node_modules' directory.
+
+        $ npm install
+
+2. Start the webpack "watch mode". This will leave the webpack compiler running
+   and compile bundles automatically when changes are made to the source files.
+   You'll need to restart this command if you make changes to the webpack config.
+
+        $ ./node_modules/.bin/webpack --config webpack.config.js --watch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       #- ./webpack-stats.json:/app/webpack-stats.json
     ports:
       - "8000:8000"
-    #command: bash -c ". /app/bin/activate && python manage.py migrate --settings=sampleproj.settings.local_defaults && python manage.py loaddata curric_titles.json --settings=sampleproj.settings.local_defaults && python manage.py runserver 0.0.0.0:8123 --settings=sampleproj.settings.local_defaults"
+    command: bash -c ". /app/bin/activate && python manage.py migrate --settings=sampleproj.settings.local && python manage.py loaddata curric_titles.json --settings=sampleproj.settings.local && python manage.py runserver 0.0.0.0:8000 --settings=sampleproj.settings.local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       #- ./webpack-stats.json:/app/webpack-stats.json
     ports:
       - "8000:8000"
-    command: bash -c ". /app/bin/activate && python manage.py migrate --settings=sampleproj.settings.local && python manage.py loaddata curric_titles.json --settings=sampleproj.settings.local && python manage.py runserver 0.0.0.0:8000 --settings=sampleproj.settings.local"
+    command: bash -c ". /app/bin/activate && python manage.py migrate --settings=sampleproj.settings.local_defaults && python manage.py loaddata curric_titles.json --settings=sampleproj.settings.local_defaults && python manage.py runserver 0.0.0.0:8000 --settings=sampleproj.settings.local_defaults"

--- a/sampleproj/settings/base.py
+++ b/sampleproj/settings/base.py
@@ -122,7 +122,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-STATIC_ROOT = '/staticfiles/'
+STATIC_ROOT = '/static/'
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',


### PR DESCRIPTION
This PR merges 'sampleproj' and 'docker' containers to use the unified Dockerfile.

docker-compose will be used primarily for getting local dev containers (using sampleproj) spun up... while the docker will be used to get a container spun up on AWS.