### PR TITLE
Fixes vue devmode issue for production.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM node:8.15.1-jessie AS wpack
 ADD . /app/
 WORKDIR /app/
 RUN npm install .
-RUN npx webpack
+RUN npx webpack --mode=production
 
 FROM django
 

--- a/prereq_map/static/prereq_map/js/components/course-infobox.vue
+++ b/prereq_map/static/prereq_map/js/components/course-infobox.vue
@@ -29,7 +29,7 @@
 
 <script>
 //import { dataBus } from "../pages/course/";
-import Vue from 'vue/dist/vue.js'
+import Vue from 'vue/dist/vue.esm.js';
 import VueShave from 'vue-shave';
 Vue.use( VueShave );
 

--- a/prereq_map/static/prereq_map/js/components/onboarding.vue
+++ b/prereq_map/static/prereq_map/js/components/onboarding.vue
@@ -82,7 +82,7 @@
 </template>
 
 <script>
-import Vue from 'vue'
+import Vue from 'vue/dist/vue.esm.js'
 import VueCookies from 'vue-cookies'
 Vue.use(VueCookies)
 

--- a/prereq_map/static/prereq_map/js/pages/course/index.js
+++ b/prereq_map/static/prereq_map/js/pages/course/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.js'
+import Vue from 'vue/dist/vue.esm.js'
 import VueRouter from 'vue-router/dist/vue-router.js'
 import VueAnalytics from 'vue-analytics'
 import App from './app.vue'

--- a/prereq_map/static/prereq_map/js/pages/curriculum/index.js
+++ b/prereq_map/static/prereq_map/js/pages/curriculum/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.js'
+import Vue from 'vue/dist/vue.esm.js'
 import VueRouter from 'vue-router/dist/vue-router.js'
 import VueAnalytics from 'vue-analytics'
 import App from './app.vue'


### PR DESCRIPTION
This is a smaller PR that just fixes the dev mode issue on production. The Dockerfile is now explicitly setting mode=production (although webpack sets production by default). I was also importing the incorrect version of "vue.js" - as it automatically sets it back to development mode. "vue.esm.js" is the correct version meant for Webpack and other bundlers.